### PR TITLE
Update bachelor_spec.rb at lines 34, 38, 42 so descriptions match test

### DIFF
--- a/lib/bachelor.rb
+++ b/lib/bachelor.rb
@@ -1,19 +1,49 @@
 def get_first_name_of_season_winner(data, season)
-  # code here
+  data[season].each do |contestant_hash|
+    if contestant_hash["status"].downcase == "winner"
+      return contestant_hash["name"].split(" ").first
+    end
+  end
 end
 
 def get_contestant_name(data, occupation)
-  # code here
+  data.each do |season, contestants|
+    contestants.each do |contestant_hash|
+      if contestant_hash["occupation"] == occupation
+        return contestant_hash["name"]
+      end
+    end
+  end
 end
 
 def count_contestants_by_hometown(data, hometown)
-  # code here
+  count = 0
+  data.each do |season, contestants|
+    contestants.each do |contestant_hash|
+      if contestant_hash["hometown"] == hometown
+        count += 1
+      end
+    end
+  end
+  count
 end
 
 def get_occupation(data, hometown)
-  # code here
+  data.each do |season, contestants|
+    contestants.each do |contestant_hash|
+      if contestant_hash["hometown"] == hometown
+        return contestant_hash['occupation']
+      end
+    end
+  end
 end
 
 def get_average_age_for_season(data, season)
-  # code here
+  age_total = 0
+  num_of_contestants = 0
+  data[season].each do |contestant_hash|
+    age_total += (contestant_hash["age"]).to_i
+    num_of_contestants += 1
+  end
+  (age_total / num_of_contestants.to_f).round(0)
 end

--- a/spec/bachelor_spec.rb
+++ b/spec/bachelor_spec.rb
@@ -31,15 +31,15 @@ describe "bachelor" do
   end
 
   describe "#count_contestants_by_hometown" do
-    it "returns 2 when passed data and the string 'New York, New York'" do
+    it "returns 4 when passed data and the string 'New York, New York'" do
       expect(count_contestants_by_hometown(data, "New York, New York")).to eq(4)
     end
 
-    it "returns 6 when passed data and the string 'Chicago, Illinois'" do
+    it "returns 8 when passed data and the string 'Chicago, Illinois'" do
       expect(count_contestants_by_hometown(data, "Chicago, Illinois")).to eq(8)
     end
 
-    it "returns 6 when passed data and the string 'San Diego, CA'" do
+    it "returns 5 when passed data and the string 'San Diego, CA'" do
       expect(count_contestants_by_hometown(data, "San Diego, California")).to eq(5)
     end
   end


### PR DESCRIPTION
test descriptions do not match number being tested.

original: 
  describe "#count_contestants_by_hometown" do
    it "returns 2 when passed data and the string 'New York, New York'" do
      expect(count_contestants_by_hometown(data, "New York, New York")).to eq(4)
    end

    it "returns 6 when passed data and the string 'Chicago, Illinois'" do
      expect(count_contestants_by_hometown(data, "Chicago, Illinois")).to eq(8)
    end

    it "returns 6 when passed data and the string 'San Diego, CA'" do
      expect(count_contestants_by_hometown(data, "San Diego, California")).to eq(5)
    end
  end

change to: 

  describe "#count_contestants_by_hometown" do
    it "returns 4 when passed data and the string 'New York, New York'" do
      expect(count_contestants_by_hometown(data, "New York, New York")).to eq(4)
    end

    it "returns 8 when passed data and the string 'Chicago, Illinois'" do
      expect(count_contestants_by_hometown(data, "Chicago, Illinois")).to eq(8)
    end

    it "returns 5 when passed data and the string 'San Diego, CA'" do
      expect(count_contestants_by_hometown(data, "San Diego, California")).to eq(5)
    end
  end